### PR TITLE
Add support for SST25VFA devices

### DIFF
--- a/spiflash/__init__.py
+++ b/spiflash/__init__.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = '0.5.2'
+__version__ = '0.6.0'
 __title__ = 'pyspiflash'
 __description__ = 'SPI data flash device drivers (pure Python)'
 __uri__ = 'http://github.com/eblot/pyspiflash'

--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -725,7 +725,7 @@ class Sst25VF010AFlashDevice(_Gen25FlashDevice):
     CMD_WRITE_STATUS_REGISTER = 0x01
     #SST25_AAI = 0b01000000    # AAI mode activation flag
     SIZES = {0x49: 1 << 20}   # 1Mbit
-    SECTOR_DIV = 12           # 4Kbit sectors (1 << 12 = 4k)
+    SECTOR_DIV = 12           # 4Kbyte sectors (1 << 12 = 4k)
     SPI_FREQ_MAX = 33         # MHz
 
     TIMINGS = {'sector': (0.025, 0.025),    # 25 ms  (typical & max)
@@ -746,10 +746,8 @@ class Sst25VF010AFlashDevice(_Gen25FlashDevice):
             raise SerialFlashUnknownJedec(jedec[0:3])
 
         mfg, dev = _SpiFlashDevice.jedec2int(jedec)[0:2]
-        # self._device = Sst25VF010AFlashDevice.DEVICES[dev]
-        # self._size = Sst25VF010AFlashDevice.SIZES[dev] #Sst25VF010AFlashDevice.SIZES[capacity]
-        self._device = Sst25VF010AFlashDevice.DEVICES[0x49]
-        self._size = Sst25VF010AFlashDevice.SIZES[0x49]
+        self._device = Sst25VF010AFlashDevice.DEVICES[dev]
+        self._size = Sst25VF010AFlashDevice.SIZES[dev]
 
         self._log = logging.getLogger(type(self).__name__)
 

--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -646,9 +646,39 @@ class Sst25FlashDevice(_Gen25FlashDevice):
             time.sleep(0.01)  # 10 ms
 
 class Sst25VF010AFlashDevice(_Gen25FlashDevice):
-    """SST25VF010A flash device implementation
+    """ SST25VF010A flash device implementation
     
-       Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/25081A.pdf
+        This device does not support JEDEC ID. This library currently requires
+        the device to support JEDEC ID, so we hack the library slightly when 
+        first attempting to access the device. This class is written so it expects
+        the JEDEC ID value to be <MFG_BYTE><DEV_BYTE><MFG_BYTE>. To get that
+        value, the SerialFlashManager must send the correct command (0x90) and
+        address, instead of the JEDEC ID command.
+
+        Example:
+ 
+        ```
+        flashMan = serialflash.SerialFlashManager
+        flashMan.CMD_JEDEC_ID = Array('B', [0x90, 0x0, 0x0, 0x0])
+        flashDev = flashMan.get_flash_device('ftdi://ftdi:232h/1', cs=0, freq=4E6)
+        print(flashDev)
+        ```
+
+        OR, if you do not use the SerialFlashManager, this device class allows a
+        user to instantiate the device object directly, without providing a JEDEC
+        ID.
+
+        Example:
+
+        ```
+        spiDev = ftdispi.SpiController()
+        spiDev.configure('ftdi://ftdi:232h/1')
+        spiSlavePort = spiDev.get_port(cs=0, freq=4E6, mode=0)
+        flashDev = serialflash.Sst25VF010AFlashDevice(spiSlavePort)
+        print(flashDev)
+        ```
+
+        Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/25081A.pdf
     """
 
     JEDEC_ID = 0xBF

--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -152,9 +152,7 @@ class SerialFlashManager(object):
         """Obtain an instance of the detected flash device"""
         ctrl = SpiController(silent_clock=False)
         ctrl.configure(url)
-        spi = ctrl.get_port(cs)
-        if freq:
-            spi.set_frequency(freq)
+        spi = ctrl.get_port(cs, freq)
         jedec = SerialFlashManager.read_jedec_id(spi)
         if not jedec:
             # it is likely that the latency setting is too low if this
@@ -898,7 +896,7 @@ class Mx25lFlashDevice(_Gen25FlashDevice):
     """Macronix MX25L flash device implementation"""
 
     JEDEC_ID = 0xC2
-    DEVICES = {0x9E: 'MX25D', 0x26: 'MX25E'}
+    DEVICES = {0x9E: 'MX25D', 0x26: 'MX25E', 0x20: 'MX25E06'}
     SIZES = {0x15: 2 << 20, 0x16: 4 << 20, 0x17: 8 << 20, 0x18: 16 << 20}
     SPI_FREQ_MAX = 104  # MHz
     TIMINGS = {'page': (0.0015, 0.003),  # 1.5/3 ms

--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -134,7 +134,7 @@ class SerialFlash(object):
         raise NotImplementedError()
 
     @classmethod
-    def match(cls, jedec):
+    def match(cls, flash_id):
         """Tells whether this class support this JEDEC identifier"""
         raise NotImplementedError()
 
@@ -148,33 +148,33 @@ class SerialFlashManager(object):
 
     CMD_JEDEC_ID = 0x9F
 
-    @staticmethod
-    def get_flash_device(url, cs=0, freq=None):
+    @classmethod
+    def get_flash_device(cls, url, cs=0, freq=None):
         """Obtain an instance of the detected flash device"""
-        ctrl = SpiController(silent_clock=False)
-        ctrl.configure(url)
-        spi = ctrl.get_port(cs, freq)
-        jedec = SerialFlashManager.read_jedec_id(spi)
+        spi = cls._get_spi_slave(url, cs, freq)
+        jedec = cls.read_jedec_id(spi)
         if not jedec:
             # it is likely that the latency setting is too low if this
             # condition is encountered
             raise SerialFlashUnknownJedec("Unable to read JEDEC Id")
-        flash = SerialFlashManager._get_flash(spi, jedec)
+        flash = cls._get_flash(spi, jedec)
         flash.set_spi_frequency(freq)
         return flash
 
-    @staticmethod
-    def read_jedec_id(spi):
+    @classmethod
+    def read_jedec_id(cls, spi):
         """Read flash device JEDEC identifier (3 bytes)"""
-        jedec_cmd = []
-        if not isinstance(SerialFlashManager.CMD_JEDEC_ID, type(Array('B', [0x0]))):
-            jedec_cmd = Array('B', (SerialFlashManager.CMD_JEDEC_ID,))
-        else:
-            jedec_cmd = SerialFlashManager.CMD_JEDEC_ID
+        jedec_cmd = Array('B', (cls.CMD_JEDEC_ID,))
         return spi.exchange(jedec_cmd, 3).tobytes()
 
-    @staticmethod
-    def _get_flash(spi, jedec):
+    @classmethod
+    def _get_spi_slave(cls, url, cs, freq):
+        ctrl = SpiController(silent_clock=False)
+        ctrl.configure(url)
+        return ctrl.get_port(cs, freq)
+
+    @classmethod
+    def _get_flash(cls, spi, jedec):
         devices = []
         contents = sys.modules[__name__].__dict__
         for name in contents:
@@ -187,6 +187,63 @@ class SerialFlashManager(object):
             raise SerialFlashUnknownJedec(jedec)
         else:
             raise SerialFlashError('No serial flash detected')
+
+
+class SerialFlashManagerNoJedec(SerialFlashManager):
+    """Serial flash manager.
+       Some flash device do not comply with JEDEC standard.
+       This alternate factory should be used with such devices.
+    """
+    @classmethod
+    def get_flash_device(cls, url, cs=0, freq=None, devfilter=None):
+        """Obtain an instance of the detected flash device"""
+        spi = cls._get_spi_slave(url, cs, freq)
+        devices = cls.get_nojedec_devices()
+        if devfilter:
+            devices = {name: dev for name, dev in devices.items()
+                       if name in devfilter}
+        for device in devices.values():
+            flash = None
+            try:
+                fid = device.get_device_id(spi)
+                if not fid:
+                    continue
+                flash = cls._get_flash(spi, fid)
+                break
+            except SerialFlashError:
+                continue
+        else:
+            raise SerialFlashUnknownJedec("Unable to detect flash device")
+        flash.set_spi_frequency(freq)
+        return flash
+
+    @classmethod
+    def read_jedec_id(cls, spi):
+        """Read flash device JEDEC identifier (3 bytes)"""
+        raise SerialFlashUnknownJedec('JEDEC ID not supported')
+
+    @staticmethod
+    def get_nojedec_devices():
+        devices = {}
+        contents = sys.modules[__name__].__dict__
+        for name in contents:
+            if name.endswith('FlashDevice') and not name.startswith('_'):
+                device = contents[name]
+                # Non-JEDEC compliant flash device should support a
+                # get_device_id classmethod which takes a single argument,
+                # a SPI port. This method should either raises a
+                # SerialFlashError exception or return None if the flash
+                # cannot succcesfully be identified.
+                try:
+                    method = getattr(device, 'get_device_id')
+                    if not callable(method):
+                        continue
+                    if method.__self__ is not device:  # is classmethod
+                        continue
+                except AttributeError:
+                    continue
+                devices[name[:-len('FlashDevice')]] = device
+        return devices
 
 
 class _SpiFlashDevice(SerialFlash):
@@ -257,72 +314,76 @@ class _SpiFlashDevice(SerialFlash):
         # If device supports chip erase and desired erase size is the entire
         # size of the chip, do chip erase.
         if (self.has_feature(SerialFlash.FEAT_CHIPERASE) and
-            (0 == address) and (self._size == (length*8))):
-            self.erase_chip(verify=verify)
-            verify=False
-        else:
-            if self.has_feature(SerialFlash.FEAT_SECTERASE):
-                # Check whether one or more whole large sector can be erased
-                sector_size = self.get_size('sector')
-                sector_mask = ~(sector_size-1)
-                s_start = (start+sector_size-1) & sector_mask
-                s_end = end & sector_mask
-                if s_start < s_end:
-                    self._erase_blocks(self.get_erase_command('sector'),
-                                    self.get_timings('sector'),
-                                    s_start, s_end, sector_size)
-                    # update the left-hand end marker
-                    end = s_start
-                    # update the right-hand start marker
-                    if s_end > rstart:
-                        rstart = s_end
-            if self.has_feature(SerialFlash.FEAT_HSECTERASE):
-                # Check whether one or more left halfsectors can be erased
-                hsector_size = self.get_size('hsector')
-                hsector_mask = ~(hsector_size-1)
-                hsl_start = (start+sector_size-1) & sector_mask
-                hsl_end = end & sector_mask
-                if hsl_start < hsl_end:
-                    self._erase_blocks(self.get_erase_command('hsector'),
-                                    self.get_timings('hsector'),
-                                    hsl_start, hsl_end, hsector_size)
-                    # update the left-hand end marker
-                    end = hsl_start
-                    # update the right-hand start marker
-                    if hsl_end > rstart:
-                        rstart = hsl_end
-            if self.has_feature(SerialFlash.FEAT_SUBSECTERASE):
-                # Check whether one or more left subsectors can be erased
-                subsector_size = self.get_size('subsector')
-                subsector_mask = ~(subsector_size-1)
-                ssl_start = (start+subsector_size-1) & subsector_mask
-                ssl_end = end & subsector_mask
-                if ssl_start < ssl_end:
-                    self._erase_blocks(self.get_erase_command('subsector'),
-                                    self.get_timings('subsector'),
-                                    ssl_start, ssl_end, subsector_size)
-                    # update the right-hand start marker
-                    if ssl_end > rstart:
-                        rstart = ssl_end
-            if self.has_feature(SerialFlash.FEAT_HSECTERASE):
-                # Check whether one or more whole left halfsectors can be erased
-                hsr_start = (rstart+hsector_size-1) & hsector_mask
-                hsr_end = rend & hsector_mask
-                if hsr_start < hsr_end:
-                    self._erase_blocks(self.get_erase_command('hsector'),
-                                    self.get_timings('hsector'),
-                                    hsr_start, hsr_end, hsector_size)
-                    # update the right-hand start marker
-                    if hsr_end > rstart:
-                        rstart = hsr_end
-            if self.has_feature(SerialFlash.FEAT_SUBSECTERASE):
-                # Check whether one or more whole right subsectors can be erased
-                ssr_start = (rstart+subsector_size-1) & subsector_mask
-                ssr_end = rend & subsector_mask
-                if ssr_start < ssr_end:
-                    self._erase_blocks(self.get_erase_command('subsector'),
-                                    self.get_timings('subsector'),
-                                    ssr_start, ssr_end, subsector_size)
+                address == 0 and len(self) == length):
+
+            # Verify is called at the end of this list of 'if' statements.
+            self.erase_chip(verify=False)
+            start = end
+            rstart = end
+            return
+
+        if self.has_feature(SerialFlash.FEAT_SECTERASE):
+            # Check whether one or more whole large sector can be erased
+            sector_size = self.get_size('sector')
+            sector_mask = ~(sector_size-1)
+            s_start = (start+sector_size-1) & sector_mask
+            s_end = end & sector_mask
+            if s_start < s_end:
+                self._erase_blocks(self.get_erase_command('sector'),
+                                self.get_timings('sector'),
+                                s_start, s_end, sector_size)
+                # update the left-hand end marker
+                end = s_start
+                # update the right-hand start marker
+                if s_end > rstart:
+                    rstart = s_end
+        if self.has_feature(SerialFlash.FEAT_HSECTERASE):
+            # Check whether one or more left halfsectors can be erased
+            hsector_size = self.get_size('hsector')
+            hsector_mask = ~(hsector_size-1)
+            hsl_start = (start+sector_size-1) & sector_mask
+            hsl_end = end & sector_mask
+            if hsl_start < hsl_end:
+                self._erase_blocks(self.get_erase_command('hsector'),
+                                self.get_timings('hsector'),
+                                hsl_start, hsl_end, hsector_size)
+                # update the left-hand end marker
+                end = hsl_start
+                # update the right-hand start marker
+                if hsl_end > rstart:
+                    rstart = hsl_end
+        if self.has_feature(SerialFlash.FEAT_SUBSECTERASE):
+            # Check whether one or more left subsectors can be erased
+            subsector_size = self.get_size('subsector')
+            subsector_mask = ~(subsector_size-1)
+            ssl_start = (start+subsector_size-1) & subsector_mask
+            ssl_end = end & subsector_mask
+            if ssl_start < ssl_end:
+                self._erase_blocks(self.get_erase_command('subsector'),
+                                self.get_timings('subsector'),
+                                ssl_start, ssl_end, subsector_size)
+                # update the right-hand start marker
+                if ssl_end > rstart:
+                    rstart = ssl_end
+        if self.has_feature(SerialFlash.FEAT_HSECTERASE):
+            # Check whether one or more whole left halfsectors can be erased
+            hsr_start = (rstart+hsector_size-1) & hsector_mask
+            hsr_end = rend & hsector_mask
+            if hsr_start < hsr_end:
+                self._erase_blocks(self.get_erase_command('hsector'),
+                                self.get_timings('hsector'),
+                                hsr_start, hsr_end, hsector_size)
+                # update the right-hand start marker
+                if hsr_end > rstart:
+                    rstart = hsr_end
+        if self.has_feature(SerialFlash.FEAT_SUBSECTERASE):
+            # Check whether one or more whole right subsectors can be erased
+            ssr_start = (rstart+subsector_size-1) & subsector_mask
+            ssr_end = rend & subsector_mask
+            if ssr_start < ssr_end:
+                self._erase_blocks(self.get_erase_command('subsector'),
+                                self.get_timings('subsector'),
+                                ssr_start, ssr_end, subsector_size)
         if verify:
             self._verify_content(address, length, 0xFF)
 
@@ -352,30 +413,26 @@ class _SpiFlashDevice(SerialFlash):
         raise SerialFlashNotSupported("Unknown erase size")
 
     def erase_chip(self, verify=False):
-        """ Erase the entire chip """
+        """Erase the entire chip"""
 
         if not self.has_feature(SerialFlash.FEAT_CHIPERASE):
-            raise SerialFlashNotSupported('Chip erase not supported by '
-                                          + type(self).__name__)
+            raise SerialFlashNotSupported('Chip erase not supported by ' +
+                                          type(self).__name__)
 
         chip_erase_timings = self.get_timings('erase_chip')
-        time_typical = chip_erase_timings[0]
-        time_max = chip_erase_timings[1]
         cmd_erase_chip = self.get_erase_command('chip')
-        #self._log.warning("Erasing all memory in flash (chip erase operation)!")
-        timeout_sec = 0
-        while self.is_busy():
-            time.sleep(0.010)  # 10 ms
-            timeout_sec += 0.010
-            if (timeout_sec >= time_max):
-                raise SerialFlashTimeout('Chip erase operation could not start. '
-                                         '(is_busy() == True after %f sec)' %
-                                         timeout_sec)
+
+        try:
+            self._wait_for_completion(chip_erase_timings)
+        except SerialFlashTimeout as e:
+            raise SerialFlashTimeout(str(e) + 
+                                    '\nChip erase operation could not start.')
         self._enable_write()
         self._spi.exchange(Array('B', (cmd_erase_chip, )))
-        self._wait_for_completion((time_typical, time_max))
+        self._wait_for_completion(chip_erase_timings)
         if self.is_busy():
-            raise SerialFlashTimeout('Chip busy after waiting for max erase time')
+            raise SerialFlashTimeout(
+                'Flash chip busy after waiting for max erase time')
 
         if verify:
             return self._verify_content(0, len(self), 0xFF)
@@ -426,7 +483,7 @@ class _SpiFlashDevice(SerialFlash):
     @classmethod
     def get_erase_command(cls, block):
         """Get the erase command for a specified block kind"""
-        raise NotImplementedError()        
+        raise NotImplementedError()
 
 
 class _Gen25FlashDevice(_SpiFlashDevice):
@@ -517,9 +574,9 @@ class _Gen25FlashDevice(_SpiFlashDevice):
         return timings[time_]
 
     @classmethod
-    def match(cls, jedec):
-        """Tells whether this class support this JEDEC identifier"""
-        manufacturer, device, capacity = cls.jedec2int(jedec)
+    def match(cls, flash_id):
+        """Tells whether this class support this device identifier"""
+        manufacturer, device, capacity = cls.jedec2int(flash_id)
         if manufacturer != cls.JEDEC_ID:
             return False
         if device not in cls.DEVICES:
@@ -686,42 +743,45 @@ class Sst25FlashDevice(_Gen25FlashDevice):
             time.sleep(0.01)  # 10 ms
 
 
-class Sst25vfxxxaFlashDevice(_Gen25FlashDevice):
-    """ SST25VFxxxA flash device implementation
-    
-        This device does not support JEDEC ID. This library currently requires
-        the device to support JEDEC ID, so we hack the library slightly when
-        first attempting to access the device. This class is written so it
-        expects the JEDEC ID value to be <MFG_BYTE><DEV_BYTE><MFG_BYTE>. To get
-        that value, the SerialFlashManager must send the correct command (0x90)
-        and address, instead of the JEDEC ID command. Override the
-        SerialFlashManager's JEDEC ID request command as shown below.
+class Sst25VfaFlashDevice(_Gen25FlashDevice):
+    """SST25VFxxxA flash device implementation
 
-        Example:
-        ```
-        flashMan = serialflash.SerialFlashManager
-        flashMan.CMD_JEDEC_ID = Array('B', [0x90, 0x0, 0x0, 0x0])
-        flashDev = flashMan.get_flash_device('ftdi://ftdi:232h/1', cs=0, freq=4E6)
-        print(flashDev)
-        ```
+       This device does not support JEDEC ID. This library currently requires
+       the device to support JEDEC ID, so we hack the library slightly when
+       first attempting to access the device. This class is written so it
+       expects the JEDEC ID value to be <MFG_BYTE><DEV_BYTE><MFG_BYTE>. To get
+       that value, the SerialFlashManager must send the correct command (0x90)
+       and address, instead of the JEDEC ID command. Override the
+       SerialFlashManager's JEDEC ID request command as shown below.
 
-        OR, if you do not use the SerialFlashManager, this device class allows a
-        user to instantiate the device object directly, without providing a
-        JEDEC ID.
+       TODO (@ahogen): Fix below docstring after new flash manager tested
 
-        Example:
-        ```
-        spiDev = ftdispi.SpiController()
-        spiDev.configure('ftdi://ftdi:232h/1')
-        spiSlavePort = spiDev.get_port(cs=0, freq=4E6, mode=0)
-        flashDev = serialflash.Sst25vfxxxaFlashDevice(spiSlavePort)
-        print(flashDev)
-        ```
+       Example:
+       ```
+       flashMan = serialflash.SerialFlashManager
+       flashMan.CMD_JEDEC_ID = Array('B', [0x90, 0x0, 0x0, 0x0])
+       flashDev = flashMan.get_flash_device('ftdi://ftdi:232h/1',
+                                            cs=0, freq=4E6)
+       print(flashDev)
+       ```
 
-        Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/25081A.pdf
+       OR, if you do not use the SerialFlashManager, this device class allows a
+       user to instantiate the device object directly, without providing a
+       JEDEC ID.
+
+       Example:
+       ```
+       spiDev = ftdispi.SpiController()
+       spiDev.configure('ftdi://ftdi:232h/1')
+       spiSlavePort = spiDev.get_port(cs=0, freq=4E6, mode=0)
+       flashDev = serialflash.Sst25VfaFlashDevice(spiSlavePort)
+       print(flashDev)
+       ```
+
+       Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/25081A.pdf
     """
 
-    JEDEC_ID = 0xBF
+    MANUFACTURER_ID = 0xBF
     DEVICES = {0x48: 'SST25VF512A', 0x49: 'SST25VF010A'}
     CMD_PROGRAM_BYTE = 0x02
     CMD_PROGRAM_WORD = 0xAF     # Auto address increment (for write command)
@@ -736,19 +796,20 @@ class Sst25vfxxxaFlashDevice(_Gen25FlashDevice):
     SUBSECTOR_DIV = 12          # 4Kbyte sectors (1 << 12 = 4k)
     SPI_FREQ_MAX = 20           # MHz
 
-    TIMINGS = {'subsector': (0.025, 0.026), # Sector erase 25 ms  (typical & max)
-               'sector' : (0.025, 0.026),   # Block erase 25 ms  (typical & max)
-               'byte' : (0.00002, 0.02),    # 20 us  (typical & max)
-               'lock': (0.0, 0.0),          # immediate
-               'erase_chip': (0.1, 0.1)}    # 100 ms (typical & max) 
+    TIMINGS = {'subsector': (0.025, 0.026),  # Sector erase 25 ms  (typ. & max)
+               'sector': (0.025, 0.026),     # Block erase 25 ms  (typ. & max)
+               'byte': (0.00002, 0.02),      # 20 us  (typical & max)
+               'lock': (0.0, 0.0),           # immediate
+               'erase_chip': (0.1, 0.1)}     # 100 ms (typical & max)
 
-    FEATURES = (SerialFlash.FEAT_SUBSECTERASE | SerialFlash.FEAT_SECTERASE
-                | SerialFlash.FEAT_CHIPERASE)
+    FEATURES = (SerialFlash.FEAT_SUBSECTERASE |
+                SerialFlash.FEAT_SECTERASE |
+                SerialFlash.FEAT_CHIPERASE)
 
-    def __init__(self, spi, jedec = None):
-        super(Sst25vfxxxaFlashDevice, self).__init__(spi)
-        if (self._spi.frequency > (Sst25vfxxxaFlashDevice.SPI_FREQ_MAX * 1E6)):
-            raise SerialFlashNotSupported("SPI port frequency too large")
+    def __init__(self, spi, flash_id=None):
+        super(Sst25VfaFlashDevice, self).__init__(spi)
+        if self._spi.frequency > (Sst25VfaFlashDevice.SPI_FREQ_MAX * 1E6):
+            raise SerialFlashNotSupported("SPI bus frequency too large")
 
         # If a write operation was canceled, say with Ctrl+C at command line,
         # device can become unresponsive (reading mfg & prod IDs returns 0xFF).
@@ -757,92 +818,103 @@ class Sst25vfxxxaFlashDevice(_Gen25FlashDevice):
         self._disable_write()
         self._wait_for_completion(self.get_timings('sector'))
 
-        # Dev doesn't support JEDEC ID. Go get mfg and dev ids instead
-        jedec = self.get_mfg_dev_id()
-        if not Sst25vfxxxaFlashDevice.match(jedec):
-            raise SerialFlashUnknownJedec(jedec[0:3])
+        # Doesn't support JEDEC, so check manufacturer and device ID
+        if flash_id is None:
+            flash_id = self.get_device_id(self._spi)
+        if not Sst25VfaFlashDevice.match(flash_id):
+            raise SerialFlashNotSupported(
+                'Device ID %s not a supported %s',
+                str(flash_id[0:3]), self.__class__.__name__)
 
-        mfg, dev = _SpiFlashDevice.jedec2int(jedec)[0:2]
-        self._device = Sst25vfxxxaFlashDevice.DEVICES[dev]
-        self._size = Sst25vfxxxaFlashDevice.SIZES[dev]
+        dev = flash_id[1]
+        self._device = Sst25VfaFlashDevice.DEVICES[dev]
+        self._size = Sst25VfaFlashDevice.SIZES[dev]
 
     def __str__(self):
         return 'Microchip %s %s' % \
             (self._device, pretty_size(self._size, lim_m=1 << 20))
 
-    def get_mfg_dev_id(self):
-        """ Read and return manufacture and device ID.
-        
-            Does not support JEDEC ID, so we read out manufacturer and device
-            ID values instead. JEDIC ID is 3 bytes, so the first and last bytes
-            are both the manufacturer ID.
+    @classmethod
+    def get_device_id(cls, spi):
+        """Read and return manufacture and device ID.
 
-            Returns:
-                [<MFG_BYTE>, <DEV_BYTE>, <MFG_BYTE>]
+           Does not support JEDEC ID, so we read out manufacturer and device
+           ID values instead. JEDIC ID is 3 bytes, so the first and last bytes
+           are both the manufacturer ID.
+
+           :return: A List in the format [<MFG_BYTE>, <DEV_BYTE>, <MFG_BYTE>]
         """
-        mfg_dev_id = self._spi.exchange(self.CMD_READ_MFG_ID, 3).tobytes()
-        #mfg_dev_id = [0xBF, 0x49, 0xBF]
-        return(mfg_dev_id)
+        if spi.frequency > (Sst25VfaFlashDevice.SPI_FREQ_MAX * 1E6):
+            raise SerialFlashNotSupported("SPI bus frequency too large")
+        mfg_dev_id = spi.exchange(cls.CMD_READ_MFG_ID, 3).tobytes()
+        return mfg_dev_id
 
     @classmethod
-    def match(cls, jedec):
-        """Tells whether this class supports a given JEDEC identifier"""
-        manufacturer, device, manufacturer_again = cls.jedec2int(jedec)
-        if ((manufacturer != cls.JEDEC_ID) and
-            (manufacturer_again != cls.JEDEC_ID)):
+    def match(cls, flash_id):
+        """Tells whether this class supports a given flash identifier.
+
+           :param flash_id: Flash ID bytes to match against supported devices
+                            in this class.
+
+           :return:         Boolean True if the provided flash ID matches a
+                            supported device in this class.
+        """
+        try:
+            mfg1, device, mfg2 = flash_id[0], flash_id[1], flash_id[2]
+        except IndexError:
+            return False
+
+        if mfg1 != cls.MANUFACTURER_ID or mfg1 != mfg2:
             return False
         if device not in cls.DEVICES:
+            return False
+        if device not in cls.SIZES:
             return False
         return True
 
     def write(self, address, data):
-        """ Write a blob of data to the SPI flash.
-        
-            Args:
-                address:  The starting address to which bytes will be written.
-                data:     The byte array to write.
-                progress: Optionally print the write progress percentage to the
-                    screen.
-            
-            Returns:
-                Number of bytes written.
+        """Write a blob of data to the SPI flash.
+
+           :param address: The starting address to which bytes will be written.
+           :param data:    The byte array to write.
+
+           :return:        Number of bytes written.
         """
         if address+len(data) > self._size:
-            raise SerialFlashValueError('Cannot fit in flash area (end addr %d > '
-                                        'max addr %d)' %
-                                        (address+len(data),
-                                        int(self._size)))
+            raise SerialFlashValueError(
+                'Cannot fit in flash area (end addr %d > max addr %d)' %
+                (address+len(data), int(self._size)))
         if not isinstance(data, Array):
             data = Array('B', data)
         length = len(data)
-        if (length == 0):
+        if length == 0:
             raise SerialFlashNotSupported('Alignment/size not supported')
         self._unprotect()
         self._enable_write()
         byte_index = 0
-        aai_cmd = Array('B', (Sst25vfxxxaFlashDevice.CMD_PROGRAM_WORD,
+        aai_cmd = Array('B', (Sst25VfaFlashDevice.CMD_PROGRAM_WORD,
                               (address >> 16) & 0xff,
                               (address >> 8) & 0xff,
                               address & 0xff, data[byte_index]))
 
         byte_times = self.get_timings('byte')
         self._wait_for_completion(byte_times)
-        
+
         while True:
             self._spi.exchange(aai_cmd)
             byte_index += 1
             self._wait_for_completion(byte_times)
             if byte_index >= length:
                 break
-            aai_cmd = Array('B', (Sst25vfxxxaFlashDevice.CMD_PROGRAM_WORD,
-                            data[byte_index]))
+            aai_cmd = Array('B', (Sst25VfaFlashDevice.CMD_PROGRAM_WORD,
+                                  data[byte_index]))
         self._disable_write()
         return byte_index
 
     def _unprotect(self):
         """Disable default protection for all sectors"""
-        en_wr_reg = Array('B', (Sst25vfxxxaFlashDevice.CMD_EWSR,))
-        unprotect = Array('B', (Sst25vfxxxaFlashDevice.CMD_WRSR, 0x00))
+        en_wr_reg = Array('B', (Sst25VfaFlashDevice.CMD_EWSR,))
+        unprotect = Array('B', (Sst25VfaFlashDevice.CMD_WRSR, 0x00))
 
         self._wait_for_completion(self.get_timings('sector'))
         self._enable_write()

--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -256,8 +256,10 @@ class _SpiFlashDevice(SerialFlash):
         # last page to erase on the right-hand size
         rend = end
 
+        # If device supports chip erase and desired erase size is the entire
+        # size of the chip, do chip erase.
         if (self.has_feature(SerialFlash.FEAT_CHIPERASE) and
-            (0 == address) and (len(self) == length)):
+            (0 == address) and (self._size == (length*8))):
             self.erase_chip(verify=verify)
             verify=False
         else:


### PR DESCRIPTION
This is kind of an odd part in that it doesn't support JEDEC ID. This class uses some work-arounds to still properly identify the device. The usage is [explained in the class's commentary](https://github.com/ahogen/pyspiflash/blob/add-dev/Microchip-SST25VF010A/spiflash/serialflash.py#L690-L722).

**NOTE:** There are some small changes/additions to the greater library. The significant changes are summarized below.

- Include `logging` library. We (the group I'm with) need logging in almost all areas of a greater Python script we're building. If you (@eblot) disagree with this addition, I can remove it from this PR and use a workaround on my end.

- Include `random` library. Simply used to generate some random data for the chip-test function.

- Add `erase_chip()`. I hoping the implementation makes it easy to add `erase_chip()` support for the other/existing devices here as well.

- (the main event...) Add support for SST25VF010A (1Mbit) and SST25VF512A (512Kbit) devices