### PR TITLE
Fix CMD_PROGRAM_PAGE with address offset

### DIFF
--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -654,12 +654,12 @@ class _Gen25FlashDevice(_SpiFlashDevice):
             sequences = [(address, data[:count]), (up, data[count:])]
         else:
             sequences = [(address, data)]
-        for addr, _ in sequences:
+        for addr, chunk in sequences:
             self._enable_write()
             wcmd = bytearray((self.CMD_PROGRAM_PAGE,
                               (addr >> 16) & 0xff, (addr >> 8) & 0xff,
                               addr & 0xff))
-            wcmd.extend(data)
+            wcmd.extend(chunk)
             self._spi.exchange(wcmd)
             self._wait_for_completion(self.get_timings('page'))
 


### PR DESCRIPTION
Minor fix: Don't write the full 256-byte page but the actual chunk as defined in the sequence. Otherwise, pages will be written incorrectly to flash if the address is not 0.