### PR TITLE
Fix copy-paste typo in get_capacity()

### DIFF
--- a/spiflash/serialflash.py
+++ b/spiflash/serialflash.py
@@ -150,7 +150,7 @@ class SerialFlash:
 
            :return: the capacity of the device, in bytes.
         """
-        raise len(self)
+        return len(self)
 
     def unlock(self) -> None:
         """Make the whole device read/write.


### PR DESCRIPTION
`SerialFlash.get_capacity()` calls `raise` instead of `return`, which causes the following error:
```
E: TypeError: exceptions must derive from BaseException
E: |-- File "C:\Dev\Python310\lib\site-packages\spiflash\serialflash.py", line 153, in get_capacity
```

I was trying to use `get_capacity()` instead of `len(flash)` because the latter is not recognized by IntelliJ (missing `__len__` in the base `SerialFlash` class).